### PR TITLE
Resolved #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ tests that have all the provided tags, use the option --tags-operand=AND, like s
 pytest --tags integration --tags MY_COMPONENT_NAME --tags-operand AND
 ```
 
+You can also display all available tags by specifyin `--tags` empty:
+```sh
+pytest --tags
+>>Available tags:
+>>foo
+>>bar
+```
+
+Tags can be combined using `pytest_tagging.combine_tags`:
+```sh
+from pytest_tagging import combine_tags
+combine_tags("all", "foo", "bar")
+```
+Then you can execute `pytest --tags all` and it will run all tests with `foo` and `bar` tags
 
 ## Extra
 - It is thread-safe, so it can be used with [pytest-parallel](https://github.com/browsertron/pytest-parallel).

--- a/pytest_tagging/__init__.py
+++ b/pytest_tagging/__init__.py
@@ -1,1 +1,3 @@
+from .plugin import combine_tags
+
 __version__ = "0.1.0"

--- a/pytest_tagging/__init__.py
+++ b/pytest_tagging/__init__.py
@@ -1,3 +1,5 @@
 from .plugin import combine_tags
 
-__version__ = "0.1.0"
+__all__ = [
+    "combine_tags",
+]

--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -91,11 +91,14 @@ class TaggerRunner:
 
         all_run_tags = get_run_tags(config.getoption("--tags"))
         if all_run_tags is not None:
+            # --tags was provided
             if len(all_run_tags) == 0:
+                # If no items in --tags
                 self._available_tags = self.get_available_tags(items)
                 for item in items:
                     deselected_items.append(item)
             else:
+                # If items in --tags
                 operand = config.getoption("--tags-operand")
 
                 # Allows you to combine tags
@@ -114,8 +117,10 @@ class TaggerRunner:
                         selected_items.append(item)
                     else:
                         deselected_items.append(item)
-
             config.hook.pytest_deselected(items=deselected_items)
+        else:
+            # --tags was not provided. Run all tests as normal
+            selected_items = items
         items[:] = selected_items
         yield
 

--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser, pluginmanager) -> None:
         "--tags",
         type=str,
         default=[],
-        nargs="+",
+        nargs="*",
         action='extend',
         help="Run the tests that contain the given tags, separated by commas",
     )

--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -16,7 +16,7 @@ _combined_tags = {}
 
 
 def combine_tags(tag_name: str, *args):
-    """ Combine all tags in `args` into `new_tag` """
+    """Combine all tags in `args` into `new_tag`"""
     _combined_tags[tag_name] = args
 
 
@@ -39,7 +39,7 @@ def pytest_addoption(parser, pluginmanager) -> None:
         type=str,
         default=[],
         nargs="*",
-        action='extend',
+        action="extend",
         help="Run the tests that contain the given tags, separated by commas",
     )
     group.addoption(
@@ -66,7 +66,6 @@ class TaggerRunner:
         """
         available_tags = []
         for item in items:
-
             test_tags = set(get_tags_from_item(item))
             for tag in test_tags:
                 if tag not in available_tags:

--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -124,8 +124,7 @@ class TaggerRunner:
         items[:] = selected_items
         yield
 
-    @pytest.mark.trylast
-    @pytest.hookimpl(hookwrapper=True)
+    @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_terminal_summary(self, terminalreporter, exitstatus, config):
         tags = get_run_tags(config.getoption("--tags"))
         if tags is not None and len(tags) == 0:

--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -11,6 +11,15 @@ class OperandChoices(Enum):
     AND = "AND"
 
 
+# Allows you to combine tags
+_combined_tags = {}
+
+
+def combine_tags(tag_name: str, *args):
+    """ Combine all tags in `args` into `new_tag` """
+    _combined_tags[tag_name] = args
+
+
 def select_counter_class(config) -> type[Counter] | type[TagCounterThreadSafe]:
     must_be_threadsafe = getattr(config.option, "workers", None) or getattr(config.option, "tests_per_worker", None)
     return TagCounterThreadSafe if must_be_threadsafe else Counter
@@ -86,6 +95,12 @@ class TaggerRunner:
                 deselected_items.append(item)
         else:
             operand = config.getoption("--tags-operand")
+
+            # Allows you to combine tags
+            found_combined_tags = set(all_run_tags) & set(_combined_tags)
+            for tag_name in found_combined_tags:
+                all_run_tags += _combined_tags[tag_name]
+
             for item in items:
                 run_tags = set(all_run_tags)
                 test_tags = get_tags_from_item(item)

--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -63,7 +63,7 @@ def pytest_addoption(parser, pluginmanager) -> None:
 class TaggerRunner:
     def __init__(self, counter_class: type[Counter] | type[TagCounterThreadSafe]) -> None:
         self.counter = counter_class()
-        self._available_tags = []
+        self._available_tags: list[str] = []
 
     def get_available_tags(self, items) -> list:
         """

--- a/pytest_tagging/utils.py
+++ b/pytest_tagging/utils.py
@@ -25,3 +25,17 @@ class TagCounterThreadSafe:
 
 def get_tags_from_item(item) -> set[str]:
     return set(item.get_closest_marker("tags").args) if item.get_closest_marker("tags") else set()
+
+
+def flatten_list(matrix: list[list]) -> list:
+    return [item for row in matrix for item in row]
+
+
+def get_run_tags(all_run_tags: list[list]) -> None | list:
+    """
+    Get
+    """
+    if len(all_run_tags) == 0:
+        return None
+    else:
+        return flatten_list(all_run_tags) if all_run_tags[0] is not None else []

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,11 +77,11 @@ class TestsTagNotSelected:
         testdir.makepyfile(
             """
             import pytest
-    
+
             @pytest.mark.tags('foo')
             def test_tagged_1():
                 assert True
-    
+
             @pytest.mark.tags('bar')
             def test_tagged_2():
                 assert True
@@ -185,7 +185,7 @@ def test_taggerrunner_with_parallel_with_processes_and_threads(testdir):
 
 def test_print_tags_available(pytester):
     pytester.makepyfile(
-    """
+        """
     import pytest
     @pytest.mark.tags('bar')
     def test_tagged1():
@@ -202,6 +202,20 @@ def test_print_tags_available(pytester):
     res.assert_outcomes(passed=0)
     assert res.stdout.str().count("bar") == 1
     assert res.stdout.str().count("foo") == 1
+
+
+def test_no_print_tags_unspecified(pytester):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.tags('bar')
+        def test_tagged1():
+            pass
+        """
+    )
+    res = pytester.runpytest("")
+
+    assert "Available tags" not in res.stdout.str()
 
 
 def test_combine_tags(pytester):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,3 +1,4 @@
+import platform
 from collections import Counter
 from unittest.mock import Mock
 
@@ -145,6 +146,7 @@ def test_summary_contains_counts(testdir):
     result.stdout.re_match_lines("foo - 1")
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="pytest-parallel not supported on Windows")
 def test_taggerrunner_with_parallel_with_processes_and_threads(testdir):
     """
     This test ensures counts are collected correctly when tests run in different processes and threads.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -184,7 +184,8 @@ def test_taggerrunner_with_parallel_with_processes_and_threads(testdir):
 
 
 def test_print_tags_available(pytester):
-    pytester.makepyfile("""
+    pytester.makepyfile(
+    """
     import pytest
     @pytest.mark.tags('bar')
     def test_tagged1():
@@ -195,7 +196,8 @@ def test_print_tags_available(pytester):
     @pytest.mark.tags('foo')
     def test_tagged3():
         pass
-    """)
+    """
+    )
     res = pytester.runpytest("--tags")
     res.assert_outcomes(passed=0)
     assert res.stdout.str().count("bar") == 1
@@ -203,7 +205,8 @@ def test_print_tags_available(pytester):
 
 
 def test_combine_tags(pytester):
-    pytester.makepyfile("""
+    pytester.makepyfile(
+        """
         import pytest
         from pytest_tagging import combine_tags
 
@@ -218,6 +221,7 @@ def test_combine_tags(pytester):
         @pytest.mark.tags('foo')
         def test_tagged3():
             pass
-        """)
+        """
+    )
     res = pytester.runpytest("--tags=new_tag")
     res.assert_outcomes(passed=3)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -200,3 +200,24 @@ def test_print_tags_available(pytester):
     res.assert_outcomes(passed=0)
     assert res.stdout.str().count("bar") == 1
     assert res.stdout.str().count("foo") == 1
+
+
+def test_combine_tags(pytester):
+    pytester.makepyfile("""
+        import pytest
+        from pytest_tagging import combine_tags
+
+        combine_tags("new_tag", "foo", "bar")
+
+        @pytest.mark.tags('bar')
+        def test_tagged1():
+            pass
+        @pytest.mark.tags('bar')
+        def test_tagged2():
+            pass
+        @pytest.mark.tags('foo')
+        def test_tagged3():
+            pass
+        """)
+    res = pytester.runpytest("--tags=new_tag")
+    res.assert_outcomes(passed=3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import threading
 
-from pytest_tagging.utils import TagCounterThreadSafe
+import pytest
+
+from pytest_tagging.utils import TagCounterThreadSafe, flatten_list, get_run_tags
 
 
 class TestTagCounterThreadSafe:
@@ -39,3 +41,21 @@ class TestTagCounterThreadSafe:
             thread.join()
 
         assert dict(counter.items()) == {"A": 5, "B": 5}
+
+
+def test_flatten_list():
+    my_list = [["foo"], ["bar"]]
+    assert flatten_list(my_list) == ["foo", "bar"]
+
+
+# First index is test data, seconds is expected result
+@pytest.mark.parametrize(
+    "tags",
+    [
+        [[], None],
+        [[[]], []],
+        [[["tag1"], ["tag2"]], ["tag1", "tag2"]],
+    ],
+)
+def test_get_run_tags(tags: list[list]):
+    assert get_run_tags(tags[0]) == tags[1]


### PR DESCRIPTION
Added support for getting all available tags by leaving --tags empty

Note I had to change the option for the --tags argument in order to support the default empty list. 
I also added a few additional testcases