### PR TITLE
#19 Fixed no tests ran when --tags unspecified

### DIFF
--- a/pytest_tagging/plugin.py
+++ b/pytest_tagging/plugin.py
@@ -113,7 +113,7 @@ class TaggerRunner:
             # Some tags were selected
             for item in items:
                 test_tags = get_tags_from_item(item)
-                if (self.config.operand is OperandChoices.OR and test_tags & all_run_tags) or (
+                if not len(all_run_tags) or (self.config.operand is OperandChoices.OR and test_tags & all_run_tags) or (
                     self.config.operand is OperandChoices.AND and all_run_tags <= test_tags
                 ):
                     selected_items.append(item)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -271,3 +271,10 @@ def test_taggerrunner_with_parallel_with_processes_and_threads(testdir):
         result = testdir.runpytest("--workers=2", "--tests-per-worker=2")
         result.stdout.re_match_lines("foo - 2")
         result.stdout.re_match_lines("bar - 3")
+
+
+def test_no_tags(pytester):
+    """Test that with no tags specified a test is still executed"""
+    pytester.makepyfile("def test_pass(): pass")
+    res = pytester.runpytest()
+    res.assert_outcomes(passed=1)


### PR DESCRIPTION
Fix for issue #19 
When no --tags is specified it should collect all testcases as selected.
+ Added testcase to catch scenario